### PR TITLE
Make the metallb config overwritable

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -4,10 +4,7 @@ parameters:
     memberlist_secretkey: ?{vaultkv:${customer:name}/${cluster:name}/metallb-memberlist/secretkey}
     speaker:
       secretname: metallb-memberlist
-    protocol: layer2
-    address_pools:
-      - name: default
-        protocol: ${metallb:protocol}
-        addresses: ${metallb:addresses}
+    configmap_name: metallb
+    config: null
     charts:
       metallb: '3b436a5ec87ffa0772d3d18a27a90dd7c717581f' # 0.1.23

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -5,6 +5,5 @@ parameters:
     speaker:
       secretname: metallb-memberlist
     configmap_name: metallb
-    config: null
     charts:
       metallb: '3b436a5ec87ffa0772d3d18a27a90dd7c717581f' # 0.1.23

--- a/class/metallb.yml
+++ b/class/metallb.yml
@@ -23,8 +23,7 @@ parameters:
         helm_values:
           speaker:
             secretName: ${metallb:speaker:secretname}
-          configInline:
-            address-pools: ${metallb:address_pools}
+          existingConfigMap: ${metallb:configmap_name}
         helm_params:
           release_name: metallb
           namespace: '${metallb:namespace}'

--- a/component/app.jsonnet
+++ b/component/app.jsonnet
@@ -6,5 +6,5 @@ local argocd = import 'lib/argocd.libjsonnet';
 local app = argocd.App('metallb', params.namespace);
 
 {
-  'metallb': app,
+  metallb: app,
 }

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -31,7 +31,9 @@ local configmap = kube.ConfigMap(params.configmap_name) {
   },
   data: {
     config:
-      if std.objectHas(params, 'addresses') then std.manifestYamlDoc({
+      if std.objectHas(params, 'addresses') && std.objectHas(params, 'config') then
+        error 'Invalid config: The variables addresses and config can not be used at the same time!'
+      else if std.objectHas(params, 'addresses') then std.manifestYamlDoc({
         'address-pools': [
           {
             name: 'default',

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -25,8 +25,26 @@ local memberlist_secret = kube.Secret(params.speaker.secretname) {
   },
 };
 
+local configmap = kube.ConfigMap(params.configmap_name) {
+  metadata+: {
+    namespace: params.namespace,
+  },
+  data: {
+    config: std.manifestYamlDoc(if params.config == null then {
+      "address-pools": [
+        {
+          "name": "default",
+          "protocol": "layer2",
+          "addresses": params.addresses,
+        },
+      ],
+    } else params.config),
+  },
+};
+
 // Define outputs below
 {
   '00_namespace': namespace,
   [if params.memberlist_secretkey != "" then '01_memberlist_secret']: memberlist_secret,
+  '02_configmap': configmap,
 }

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -30,15 +30,18 @@ local configmap = kube.ConfigMap(params.configmap_name) {
     namespace: params.namespace,
   },
   data: {
-    config: std.manifestYamlDoc(if params.config == null then {
-      "address-pools": [
-        {
-          "name": "default",
-          "protocol": "layer2",
-          "addresses": params.addresses,
-        },
-      ],
-    } else params.config),
+    config:
+      if std.objectHas(params, 'addresses') then std.manifestYamlDoc({
+        "address-pools": [
+          {
+            "name": "default",
+            "protocol": "layer2",
+            "addresses": params.addresses,
+          },
+        ],
+      })
+      else if std.objectHas(params, 'config') then std.manifestYamlDoc(params.config)
+      else error "The addresses array must contain at least one virtual IP or an override config must be configured!",
   },
 };
 

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -48,6 +48,6 @@ local configmap = kube.ConfigMap(params.configmap_name) {
 // Define outputs below
 {
   '00_namespace': namespace,
-  [if params.memberlist_secretkey != "" then '01_memberlist_secret']: memberlist_secret,
+  [if params.memberlist_secretkey != '' then '01_memberlist_secret']: memberlist_secret,
   '02_configmap': configmap,
 }

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -32,16 +32,16 @@ local configmap = kube.ConfigMap(params.configmap_name) {
   data: {
     config:
       if std.objectHas(params, 'addresses') then std.manifestYamlDoc({
-        "address-pools": [
+        'address-pools': [
           {
-            "name": "default",
-            "protocol": "layer2",
-            "addresses": params.addresses,
+            name: 'default',
+            protocol: 'layer2',
+            addresses: params.addresses,
           },
         ],
       })
       else if std.objectHas(params, 'config') then std.manifestYamlDoc(params.config)
-      else error "The addresses array must contain at least one virtual IP or an override config must be configured!",
+      else error 'The addresses array must contain at least one virtual IP or an override config must be configured!',
   },
 };
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -23,7 +23,7 @@ It can be generated using the command `openssl rand -base64 128`.
 == `addresses`
 
 [horizontal]
-type:: ip list
+type:: list
 default:: null
 
 A list of IPs (for example `10.128.1.200/32`) used as transferable virtual IPs.
@@ -32,10 +32,12 @@ A list of IPs (for example `10.128.1.200/32`) used as transferable virtual IPs.
 == `config`
 
 [horizontal]
-type:: yaml config
+type:: dictionary
 default:: null
 
-A custom config can be provided. This overrides the automatic config generation and passes the value direct into the config map.
+A custom config can be provided. This overrides the automatic config generation.
+
+NOTE: The passed configuration is not going to be validated by the component.
 
 For example this allows to specify multiple address pools:
 ```

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -20,24 +20,36 @@ default:: Vault reference
 A binary secret key encoded base64.
 It can be generated using the command `openssl rand -base64 128`.
 
-
-== `protocol`
-
-[horizontal]
-type:: string
-default:: `layer2`
-
-MetalLB supports https://metallb.universe.tf/concepts/layer2/[Layer2] `layer2` and https://metallb.universe.tf/concepts/bgp/[BGP] `bgp`.
-As layer2 is often used on-premis, this is the default.
-
-
 == `addresses`
 
 [horizontal]
 type:: ip list
 default:: null
 
-A list of IPs  (for example `10.128.1.200/32`) used as transferable virtual IPs.
+A list of IPs (for example `10.128.1.200/32`) used as transferable virtual IPs.
+
+
+== `config`
+
+[horizontal]
+type:: yaml config
+default:: null
+
+A custom config can be provided. This overrides the automatic config generation and passes the value direct into the config map.
+
+For example this allows to specify multiple address pools:
+```
+    config:
+      address-pools:
+        - name: pool1
+          protocol: layer2
+          addresses:
+            - 10.128.1.200/32
+        - name: pool2
+          protocol: layer2
+          addresses:
+            - 10.128.2.200/32
+````
 
 
 == `charts.metallb`

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -35,7 +35,8 @@ A list of IPs (for example `10.128.1.200/32`) used as transferable virtual IPs.
 type:: dictionary
 default:: null
 
-A custom config can be provided. This overrides the automatic config generation.
+A custom config can be provided.
+This overrides the automatic config generation.
 
 NOTE: The passed configuration is not going to be validated by the component.
 


### PR DESCRIPTION
The configuration should be simple for simple use cases. On the other hand complex configurations should can be done anytime.

This change does generate a default config with the ip addresses and layer2 as protocol. For more advanced configurations a full metallb config can be provided.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.

