### PR TITLE
Move postprocessing filter definitions to component class

### DIFF
--- a/class/metallb.yml
+++ b/class/metallb.yml
@@ -27,3 +27,13 @@ parameters:
         helm_params:
           release_name: metallb
           namespace: '${metallb:namespace}'
+
+  commodore:
+    postprocess:
+      filters:
+        - path: metallb/10_metallb_helmchart/metallb/templates
+          type: builtin
+          filter: helm_namespace
+          filterargs:
+            namespace: ${metallb:namespace}
+            create_namespace: "false"

--- a/postprocess/filters.yml
+++ b/postprocess/filters.yml
@@ -1,7 +1,0 @@
-filters:
-  - path: metallb/10_metallb_helmchart/metallb/templates
-    type: builtin
-    filter: helm_namespace
-    filterargs:
-      namespace: ${metallb:namespace}
-      create_namespace: "false"


### PR DESCRIPTION
Filter definitions in postprocess/filters.yml have been soft-deprecated since Commodore v0.4.0, and will be fully deprecated in v0.16.0, cf. https://syn.tools/commodore/reference/deprecation-notices.html#_external_pp_filters




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
