### PR TITLE
Change helm release_name to name

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,6 +1,7 @@
 parameters:
   metallb:
     namespace: syn-metallb
+    name: metallb
     memberlist_secretkey: ?{vaultkv:${customer:name}/${cluster:name}/metallb-memberlist/secretkey}
     speaker:
       secretname: metallb-memberlist

--- a/class/metallb.yml
+++ b/class/metallb.yml
@@ -25,7 +25,7 @@ parameters:
             secretName: ${metallb:speaker:secretname}
           existingConfigMap: ${metallb:configmap_name}
         helm_params:
-          release_name: metallb
+          name: ${metallb:name}
           namespace: '${metallb:namespace}'
 
   commodore:

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -10,6 +10,14 @@ type:: string
 default:: `syn-metallb`
 
 
+== `name`
+
+[horizontal]
+type:: string
+default:: `metallb`
+
+Usually there is just one deployment and therefore no change is required.
+
 
 == `speaker.secretkey`
 


### PR DESCRIPTION
When compiling the component, a warning would be emmitted:

> using 'release_name' to specify the output name is deprecated. Use
> 'name' instead

This commit addresses this

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
