### PR TITLE
Fix tenant name reclass references

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -2,7 +2,7 @@ parameters:
   metallb:
     namespace: syn-metallb
     name: metallb
-    memberlist_secretkey: ?{vaultkv:${customer:name}/${cluster:name}/metallb-memberlist/secretkey}
+    memberlist_secretkey: ?{vaultkv:${cluster:tenant}/${cluster:name}/metallb-memberlist/secretkey}
     speaker:
       secretname: metallb-memberlist
     configmap_name: metallb


### PR DESCRIPTION
We've deprecated `customer.name` a while ago.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
