### PR TITLE
Add parameter `helm_values`

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -10,3 +10,7 @@ parameters:
       metallb:
         source: https://metallb.github.io/metallb
         version: 0.12.1
+    helm_values:
+      speaker:
+        secretName: ${metallb:speaker:secretname}
+      existingConfigMap: ${metallb:configmap_name}

--- a/class/metallb.yml
+++ b/class/metallb.yml
@@ -20,10 +20,7 @@ parameters:
         output_type: yaml
         input_paths:
           - metallb/helmcharts/metallb-${metallb:charts:metallb:version}
-        helm_values:
-          speaker:
-            secretName: ${metallb:speaker:secretname}
-          existingConfigMap: ${metallb:configmap_name}
+        helm_values: ${metallb:helm_values}
         helm_params:
           name: ${metallb:name}
           namespace: "${metallb:namespace}"

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -79,3 +79,11 @@ type:: string
 default:: See https://github.com/projectsyn/component-metallb/blob/master/class/defaults.yml[class/defaults.yml]
 
 The version of the `metallb` chart that's used.
+
+== `helm_values`
+
+[horizontal]
+default:: See https://github.com/projectsyn/component-metallb/blob/master/class/defaults.yml[class/defaults.yml]
+
+The Helm values to use when rendering the MetalLB Helm chart.
+See the chart's https://github.com/metallb/metallb/blob/main/charts/metallb/values.yaml[`values.yaml`] for supported fields.


### PR DESCRIPTION
This allows users to configure the metallb Helm chart through the hierarchy. This change doesn't impact existing setups.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
