### PR TITLE
Ignore changes to CRD conversion webhook CA bundles

### DIFF
--- a/component/app.jsonnet
+++ b/component/app.jsonnet
@@ -3,7 +3,19 @@ local inv = kap.inventory();
 local params = inv.parameters.metallb;
 local argocd = import 'lib/argocd.libjsonnet';
 
-local app = argocd.App('metallb', params.namespace);
+local app = argocd.App('metallb', params.namespace) {
+  spec+: {
+    ignoreDifferences: [
+      {
+        group: 'apiextensions.k8s.io',
+        kind: 'CustomResourceDefinition',
+        jsonPointers: [
+          '/spec/conversion/webhook/clientConfig/caBundle',
+        ],
+      },
+    ],
+  },
+};
 
 {
   metallb: app,

--- a/tests/golden/addresses/metallb/apps/metallb.yaml
+++ b/tests/golden/addresses/metallb/apps/metallb.yaml
@@ -1,0 +1,6 @@
+spec:
+  ignoreDifferences:
+    - group: apiextensions.k8s.io
+      jsonPointers:
+        - /spec/conversion/webhook/clientConfig/caBundle
+      kind: CustomResourceDefinition

--- a/tests/golden/defaults/metallb/apps/metallb.yaml
+++ b/tests/golden/defaults/metallb/apps/metallb.yaml
@@ -1,0 +1,6 @@
+spec:
+  ignoreDifferences:
+    - group: apiextensions.k8s.io
+      jsonPointers:
+        - /spec/conversion/webhook/clientConfig/caBundle
+      kind: CustomResourceDefinition

--- a/tests/golden/legacy/metallb/apps/metallb.yaml
+++ b/tests/golden/legacy/metallb/apps/metallb.yaml
@@ -1,0 +1,6 @@
+spec:
+  ignoreDifferences:
+    - group: apiextensions.k8s.io
+      jsonPointers:
+        - /spec/conversion/webhook/clientConfig/caBundle
+      kind: CustomResourceDefinition


### PR DESCRIPTION
The metallb controller manages that field, so we need to ensure that those changes aren't reverted by ArgoCD.

This PR configures ArgoCD to ignore changes to the conversion webhook CA bundles.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
