### PR TITLE
Replace `gcr.io` `kube-rbac-proxy` image

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -11,9 +11,18 @@ parameters:
       metallb:
         source: https://metallb.github.io/metallb
         version: 0.13.9
+    images:
+      kube_rbac_proxy:
+        registry: quay.io
+        repository: brancz/kube-rbac-proxy
+        tag: v0.18.2
     helm_values:
       speaker:
         secretName: ${metallb:speaker:secretname}
+      prometheus:
+        rbacProxy:
+          repository: ${metallb:images:kube_rbac_proxy:registry}/${metallb:images:kube_rbac_proxy:repository}
+          tag: ${metallb:images:kube_rbac_proxy:tag}
 
     # Config inputs
     ipAddressPools: {}

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -10,3 +10,8 @@ parameters:
         spec:
           ipAddressPools:
             - default
+
+    # To test with rbac-proxy
+    helm_values:
+      prometheus:
+        secureMetricsPort: 666

--- a/tests/golden/defaults/metallb/metallb/10_metallb_helmchart/metallb/templates/controller.yaml
+++ b/tests/golden/defaults/metallb/metallb/10_metallb_helmchart/metallb/templates/controller.yaml
@@ -70,6 +70,22 @@ spec:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert
               readOnly: true
+        - args:
+            - --logtostderr
+            - --secure-listen-address=:666
+            - --upstream=http://127.0.0.1:7472/
+            - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+          image: quay.io/brancz/kube-rbac-proxy:v0.18.2
+          imagePullPolicy: null
+          name: kube-rbac-proxy
+          ports:
+            - containerPort: 666
+              name: metricshttps
+          resources:
+            requests:
+              cpu: 10m
+              memory: 20Mi
+          terminationMessagePolicy: FallbackToLogsOnError
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:

--- a/tests/golden/defaults/metallb/metallb/10_metallb_helmchart/metallb/templates/rbac.yaml
+++ b/tests/golden/defaults/metallb/metallb/10_metallb_helmchart/metallb/templates/rbac.yaml
@@ -81,6 +81,18 @@ rules:
     verbs:
       - list
       - watch
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -119,6 +131,18 @@ rules:
     verbs:
       - create
       - patch
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/tests/golden/defaults/metallb/metallb/10_metallb_helmchart/metallb/templates/speaker.yaml
+++ b/tests/golden/defaults/metallb/metallb/10_metallb_helmchart/metallb/templates/speaker.yaml
@@ -85,6 +85,27 @@ spec:
           volumeMounts:
             - mountPath: /etc/ml_secret_key
               name: memberlist
+        - args:
+            - --logtostderr
+            - --secure-listen-address=:666
+            - --upstream=http://$(METALLB_HOST):7472/
+            - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+          env:
+            - name: METALLB_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          image: quay.io/brancz/kube-rbac-proxy:v0.18.2
+          imagePullPolicy: IfNotPresent
+          name: kube-rbac-proxy
+          ports:
+            - containerPort: 666
+              name: metricshttps
+          resources:
+            requests:
+              cpu: 10m
+              memory: 20Mi
+          terminationMessagePolicy: FallbackToLogsOnError
       hostNetwork: true
       nodeSelector:
         kubernetes.io/os: linux


### PR DESCRIPTION
`gcr.io` is deprecated and will be removed https://cloud.google.com/artifact-registry/docs/transition/prepare-gcr-shutdown

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
